### PR TITLE
fix(uglifyJS): use Compress API not ast.transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/webpack-contrib/uglifyjs-webpack-plugin",
   "peerDependencies": {
-    "uglify-js": "^2.7.5",
+    "uglify-js": "^2.8.0",
     "webpack": "^1.9 || ^2 || ^2.1.0-beta || ^2.2.0-rc"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class UglifyJsPlugin {
 							const compress = uglify.Compressor(options.compress || {
 								warnings: false
 							}); // eslint-disable-line new-cap
-							ast = ast.transform(compress);
+							ast = compress.compress(ast);
 						}
 						if(options.mangle !== false) {
 							ast.figure_out_scope(options.mangle || {});


### PR DESCRIPTION
  - Bumps uglify-js peerDep to ^2.8.0

Closes #15