### PR TITLE
Fix the UglifyJS2 README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
       src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
   </a>
   <h1>UglifyJS Webpack Plugin</h1>
-  <p>This plugin uses [UglifyJS](https://github.com/mishoo/UglifyJS2) to minify your JavaScript.<p>
+	<p>This plugin uses <a href="https://github.com/mishoo/UglifyJS2">UglifyJS</a> to minify your JavaScript.<p>
 </div>
 
 > Note that webpack contains the same plugin under `webpack.optimize.UglifyJsPlugin`. This is a standalone version for those that want to control the version of UglifyJS. The documentation is valid apart from the installation instructions in that case.


### PR DESCRIPTION
Markdown doesn't support having markdown inside of HTML, so the UglifyJS link wasn't rendering properly.  Now it will.