### PR TITLE
Updated readme to reflect last compatible version of UglifyJS2#harmony

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install uglifyjs-webpack-plugin --save-dev
 If your minification target is ES6:
 
 ```bash
-yarn add git://github.com/mishoo/UglifyJS2#harmony --dev
+yarn add git://github.com/mishoo/UglifyJS2#harmony-v2.8.22 --dev
 ```
 
 If your minification target is ES5:


### PR DESCRIPTION
As @bebraw noted in https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/33#issuecomment-302948338, the plugin is not yet compatible with V3 of UglifyJS2, so the Readme should point to the last working version for now.