### PR TITLE
refactor: changed `__UglifyJsPlugin` dereference to use `WeakSet` instead

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,14 +50,14 @@ class UglifyJsPlugin {
         // eslint-disable-next-line prefer-spread
         files.push.apply(files, compilation.additionalChunkAssets);
         const filteredFiles = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
+        const uglifiedAssets = new WeakSet();
         filteredFiles.forEach((file) => {
           const oldWarnFunction = uglify.AST_Node.warn_function;
           const warnings = [];
           let sourceMap;
           try {
             const asset = compilation.assets[file];
-            if (asset.__UglifyJsPlugin) {
-              compilation.assets[file] = asset.__UglifyJsPlugin;
+            if (uglifiedAssets.has(asset)) {
               return;
             }
             let input;
@@ -220,9 +220,7 @@ class UglifyJsPlugin {
                 }
               }
             }
-            compilation.assets[file] = outputSource;
-            asset.__UglifyJsPlugin = outputSource;
-
+            uglifiedAssets.add(compilation.assets[file] = outputSource);
             if (warnings.length > 0) {
               compilation.warnings.push(new Error(`${file} from UglifyJs\n${warnings.join('\n')}`));
             }


### PR DESCRIPTION
So, as a proof of concept... I created this: https://github.com/hulkish/dummy

Pull that repo, then run:

```
yarn
node scripts/profile.js
```

You will see an output which looks like:
```
untouched_node@v6.11.0 compile...
untouched_node@v6.11.0 files length 68
untouched_node@v6.11.0 profiler.startProfiling()
untouched_node@v6.11.0: 27549.784ms
untouched_node@v6.11.0 profiler.stopProfiling()
untouched_node@v6.11.0 profile.export()
untouched_node@v6.11.0 profile saved: /Users/shargrove/dev/repos/dummy/untouched_node@v6.11.0.uglifyjs-webpack-plugin.cpuprofile
forEach_WeakSet_node@v6.11.0 compile...
forEach_WeakSet_node@v6.11.0 files length 68
forEach_WeakSet_node@v6.11.0 profiler.startProfiling()
forEach_WeakSet_node@v6.11.0: 14367.834ms
forEach_WeakSet_node@v6.11.0 profiler.stopProfiling()
forEach_WeakSet_node@v6.11.0 profile.export()
forEach_WeakSet_node@v6.11.0 profile saved: /Users/shargrove/dev/repos/dummy/forEach_WeakSet_node@v6.11.0.uglifyjs-webpack-plugin.cpuprofile
```

then, you can compare the output of these 2 folders:
- `dist/untouched_node@v6.11.0`
- `dist/forEach_WeakSet_node@v6.11.0`

The output is the same, but look at the significant difference in time.