### PR TITLE
test: add test for `MultiCompiler` usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5410,9 +5410,9 @@
       "dev": true
     },
     "uglify-es": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.0.21.tgz",
-      "integrity": "sha512-hJ0lb3CoazL8TANWJCb6TusMOvcBSZp5vRiA3PST+LzwedUOguvf4xcpPwQGRS5GnaLYll9DQEL/jr8HPAioMg==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.0.24.tgz",
+      "integrity": "sha512-5BfuaLWF0idSXopD0iAK6osMvyo1jEyuQ8MtSpOdLvqUDjlfDDf18qEyz3M7athqorybUuAoKpKW1DhFIhxP2w==",
       "dependencies": {
         "commander": {
           "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "source-map": "^0.5.6",
-    "uglify-es": "^3.0.21",
+    "uglify-es": "^3.0.24",
     "webpack-sources": "^1.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,10 @@ class UglifyJsPlugin {
   }
 
   apply(compiler) {
-    const requestShortener = new RequestShortener(compiler.context);
+    if (UglifyJsPlugin.appliedCompilers.has(compiler)) return;
+    UglifyJsPlugin.appliedCompilers.add(compiler);
+
+    const requestShortener = new RequestShortener(compiler.context || process.cwd());
     // Copy uglify options
     const uglifyOptions = UglifyJsPlugin.buildDefaultUglifyOptions(this.uglifyOptions);
     // Making sure output options exists if there is an extractComments options
@@ -279,5 +282,12 @@ class UglifyJsPlugin {
     });
   }
 }
+
+Object.defineProperty(UglifyJsPlugin, 'appliedCompilers', {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: new WeakSet(),
+});
 
 export default UglifyJsPlugin;

--- a/src/index.js
+++ b/src/index.js
@@ -149,9 +149,6 @@ class UglifyJsPlugin {
   }
 
   apply(compiler) {
-    if (UglifyJsPlugin.appliedCompilers.has(compiler)) return;
-    UglifyJsPlugin.appliedCompilers.add(compiler);
-
     const requestShortener = new RequestShortener(compiler.context || process.cwd());
     // Copy uglify options
     const uglifyOptions = UglifyJsPlugin.buildDefaultUglifyOptions(this.uglifyOptions);
@@ -282,12 +279,5 @@ class UglifyJsPlugin {
     });
   }
 }
-
-Object.defineProperty(UglifyJsPlugin, 'appliedCompilers', {
-  enumerable: false,
-  configurable: false,
-  writable: false,
-  value: new WeakSet(),
-});
 
 export default UglifyJsPlugin;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
   Author Tobias Koppers @sokra
 */
 
+import path from 'path';
 import { SourceMapConsumer } from 'source-map';
 import { SourceMapSource, RawSource, ConcatSource } from 'webpack-sources';
 import RequestShortener from 'webpack/lib/RequestShortener';
@@ -149,7 +150,7 @@ class UglifyJsPlugin {
   }
 
   apply(compiler) {
-    const requestShortener = new RequestShortener(compiler.context || process.cwd());
+    const requestShortener = new RequestShortener(compiler.context || path.resolve());
     // Copy uglify options
     const uglifyOptions = UglifyJsPlugin.buildDefaultUglifyOptions(this.uglifyOptions);
     // Making sure output options exists if there is an extractComments options

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
   Author Tobias Koppers @sokra
 */
 
-import path from 'path';
 import { SourceMapConsumer } from 'source-map';
 import { SourceMapSource, RawSource, ConcatSource } from 'webpack-sources';
 import RequestShortener from 'webpack/lib/RequestShortener';
@@ -150,7 +149,7 @@ class UglifyJsPlugin {
   }
 
   apply(compiler) {
-    const requestShortener = new RequestShortener(compiler.context || path.resolve());
+    const requestShortener = new RequestShortener(compiler.context);
     // Copy uglify options
     const uglifyOptions = UglifyJsPlugin.buildDefaultUglifyOptions(this.uglifyOptions);
     // Making sure output options exists if there is an extractComments options

--- a/test/__snapshots__/es2015.test.js.snap
+++ b/test/__snapshots__/es2015.test.js.snap
@@ -121,7 +121,7 @@ exports[`es6: main.96c5ba3d7f23066ac123.js 1`] = `
 `;
 
 exports[`es6: manifest.a458e5044f91a97906ab.js 1`] = `
-"!(modules => {
+"(modules => {
     function __webpack_require__(moduleId) {
         if (installedModules[moduleId]) return installedModules[moduleId].exports;
         var module = installedModules[moduleId] = {
@@ -217,7 +217,7 @@ exports[`es7: main.96c5ba3d7f23066ac123.js 1`] = `
 `;
 
 exports[`es7: manifest.a458e5044f91a97906ab.js 1`] = `
-"!(modules => {
+"(modules => {
     function __webpack_require__(moduleId) {
         if (installedModules[moduleId]) return installedModules[moduleId].exports;
         var module = installedModules[moduleId] = {
@@ -313,7 +313,7 @@ exports[`es8: main.96c5ba3d7f23066ac123.js 1`] = `
 `;
 
 exports[`es8: manifest.a458e5044f91a97906ab.js 1`] = `
-"!(modules => {
+"(modules => {
     function __webpack_require__(moduleId) {
         if (installedModules[moduleId]) return installedModules[moduleId].exports;
         var module = installedModules[moduleId] = {

--- a/test/__snapshots__/supports-multicompiler.test.js.snap
+++ b/test/__snapshots__/supports-multicompiler.test.js.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compiler plugin count 1`] = `
+Object {
+  "after-emit": 1,
+  "after-resolvers": 2,
+  "before-run": 1,
+  "compilation": 32,
+  "done": 1,
+  "entry-option": 1,
+  "invalid": 1,
+  "make": 1,
+  "this-compilation": 1,
+}
+`;
+
+exports[`errors 1`] = `Array []`;
+
+exports[`errors 2`] = `Array []`;
+
+exports[`errors 3`] = `Array []`;
+
+exports[`main.4e5a10269ba18219d140.js 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+// foo
+/* @preserve*/
+// bar
+const a = 2 + 2;
+
+module.exports = function Foo() {
+  const b = 2 + 2;
+  console.log(b + 1 + 2);
+};
+
+
+/***/ })
+/******/ ]);"
+`;
+
+exports[`main.4e5a10269ba18219d140.js 2`] = `"!function(n){function t(r){if(e[r])return e[r].exports;var o=e[r]={i:r,l:!1,exports:{}};return n[r].call(o.exports,o,o.exports,t),o.l=!0,o.exports}var e={};t.m=n,t.c=e,t.d=function(n,e,r){t.o(n,e)||Object.defineProperty(n,e,{configurable:!1,enumerable:!0,get:r})},t.n=function(n){var e=n&&n.__esModule?function(){return n.default}:function(){return n};return t.d(e,\\"a\\",e),e},t.o=function(n,t){return Object.prototype.hasOwnProperty.call(n,t)},t.p=\\"\\",t(t.s=0)}([function(n,t){n.exports=function(){console.log(7)}}]);"`;
+
+exports[`main.db8335aef59d7a30f804.js 1`] = `"!function(t){function e(n){if(r[n])return r[n].exports;var o=r[n]={i:n,l:!1,exports:{}};return t[n].call(o.exports,o,o.exports,e),o.l=!0,o.exports}var r={};e.m=t,e.c=r,e.d=function(t,r,n){e.o(t,r)||Object.defineProperty(t,r,{configurable:!1,enumerable:!0,get:n})},e.n=function(t){var r=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(r,\\"a\\",r),r},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p=\\"\\",e(e.s=0)}([function(t,e,r){\\"use strict\\";Object.defineProperty(e,\\"__esModule\\",{value:!0});var n=r(1);e.default=function(){const t=n.b,e=\`baz\${Math.random()}\`;return()=>({a:t+n.a+e,b:t,baz:e})}},function(t,e,r){\\"use strict\\";e.a=\\"bar\\",e.b=\\"foo\\"}]);"`;
+
+exports[`warnings 1`] = `Array []`;
+
+exports[`warnings 2`] = `Array []`;
+
+exports[`warnings 3`] = `Array []`;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -54,14 +54,8 @@ export function createCompiler(options = {}) {
 
 export function countPlugins({ _plugins }) {
   return Object.keys(_plugins).reduce((aggregate, name) => {
-    const currentLength = typeof aggregate[name] === 'number' ? aggregate[name].length : 0;
     const eventLength = Array.isArray(_plugins[name]) ? _plugins[name].length : 0;
-
-    if (eventLength > currentLength) {
-      Object.assign(aggregate, {
-        [name]: eventLength,
-      });
-    }
+    aggregate[name] = eventLength; // eslint-disable-line no-param-reassign
     return aggregate;
   }, {});
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,7 @@
 import MemoryFileSystem from 'memory-fs'; // eslint-disable-line import/no-extraneous-dependencies
 import webpack from 'webpack';
 
-exports.PluginEnvironment = class PluginEnvironment {
+export class PluginEnvironment {
   constructor() {
     this.events = [];
   }
@@ -20,19 +20,19 @@ exports.PluginEnvironment = class PluginEnvironment {
   getEventBindings() {
     return this.events;
   }
-};
+}
 
-exports.compile = function compile(compiler) {
+export function compile(compiler) {
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => { // eslint-disable-line consistent-return
       if (err) return reject(err);
       resolve(stats);
     });
   });
-};
+}
 
-exports.createCompiler = function createCompiler(options = {}) {
-  const compiler = webpack({
+export function createCompiler(options = {}) {
+  const compiler = webpack(Array.isArray(options) ? options : {
     bail: true,
     cache: false,
     entry: `${__dirname}/fixtures/entry.js`,
@@ -50,15 +50,29 @@ exports.createCompiler = function createCompiler(options = {}) {
   });
   compiler.outputFileSystem = new MemoryFileSystem();
   return compiler;
-};
+}
 
-exports.removeCWD = function removeCWD(str) {
+export function countPlugins({ _plugins }) {
+  return Object.keys(_plugins).reduce((aggregate, name) => {
+    const currentLength = typeof aggregate[name] === 'number' ? aggregate[name].length : 0;
+    const eventLength = Array.isArray(_plugins[name]) ? _plugins[name].length : 0;
+
+    if (eventLength > currentLength) {
+      Object.assign(aggregate, {
+        [name]: eventLength,
+      });
+    }
+    return aggregate;
+  }, {});
+}
+
+export function removeCWD(str) {
   return str.split(`${process.cwd()}/`).join('');
-};
+}
 
-exports.cleanErrorStack = function cleanErrorStack(error) {
+export function cleanErrorStack(error) {
   const str = exports.removeCWD(error.toString())
     .split('\n').slice(0, 2).join('\n');
   return str;
-};
+}
 

--- a/test/supports-multicompiler.test.js
+++ b/test/supports-multicompiler.test.js
@@ -1,0 +1,84 @@
+import MultiCompiler from 'webpack/lib/MultiCompiler';
+import MultiStats from 'webpack/lib/MultiStats';
+import UglifyJsPlugin from '../src/index';
+import {
+  cleanErrorStack,
+  createCompiler,
+  countPlugins,
+  compile,
+} from './helpers';
+
+describe('when using MultiCompiler with empty options', () => {
+  it('matches snapshot', () => {
+    const multiCompiler = createCompiler([
+      {
+        bail: true,
+        cache: false,
+        entry: `${__dirname}/fixtures/entry.js`,
+        output: {
+          path: `${__dirname}/dist`,
+          filename: '[name].[chunkhash].js',
+          chunkFilename: '[id].[name].[chunkhash].js',
+        },
+      },
+      {
+        bail: true,
+        cache: false,
+        entry: `${__dirname}/fixtures/entry.js`,
+        output: {
+          path: `${__dirname}/dist`,
+          filename: '[name].[chunkhash].js',
+          chunkFilename: '[id].[name].[chunkhash].js',
+        },
+        plugins: [new UglifyJsPlugin()],
+      },
+      {
+        bail: true,
+        cache: false,
+        entry: `${__dirname}/fixtures/es2015/entry.js`,
+        output: {
+          path: `${__dirname}/dist-MultiCompiler`,
+          filename: '[name].[chunkhash].js',
+          chunkFilename: '[id].[name].[chunkhash].js',
+        },
+        plugins: [new UglifyJsPlugin()],
+      },
+    ]);
+
+    const emptyPluginCount = countPlugins(multiCompiler.compilers[0]);
+    const expectedPluginCount = countPlugins(multiCompiler.compilers[1]);
+
+    expect(emptyPluginCount).not.toEqual(expectedPluginCount);
+    expect(multiCompiler).toBeInstanceOf(MultiCompiler);
+
+    multiCompiler.compilers.slice(2).forEach((compiler) => {
+      const pluginCount = countPlugins(compiler);
+      expect(pluginCount).not.toEqual(emptyPluginCount);
+      expect(pluginCount).toEqual(expectedPluginCount);
+      expect(pluginCount).toMatchSnapshot('compiler plugin count');
+    });
+
+    expect(multiCompiler).toBeInstanceOf(MultiCompiler);
+
+    return compile(multiCompiler).then((multiStats) => {
+      expect(multiStats).toBeInstanceOf(MultiStats);
+
+      multiStats.stats.forEach((stats) => {
+        const errors = stats.compilation.errors.map(cleanErrorStack);
+        const warnings = stats.compilation.warnings.map(cleanErrorStack);
+
+        expect(errors.length).toEqual(0);
+        expect(warnings.length).toEqual(0);
+
+        expect(errors).toMatchSnapshot('errors');
+        expect(warnings).toMatchSnapshot('warnings');
+
+        for (const file in stats.compilation.assets) {
+          if (Object.prototype.hasOwnProperty.call(stats.compilation.assets, file)) {
+            expect(stats.compilation.assets[file].source()).toMatchSnapshot(file);
+          }
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #73

**Update:** So, it looks like this issue just *magically fixed itself*. That, said - I'd like to still include the added tests and upgrade to `uglify-es@3.0.24`.