### PR TITLE
fix(index): deep cloning options (`options.uglifyOptions`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,11 @@ class UglifyJsPlugin {
   constructor(options) {
     if (typeof options !== 'object' || Array.isArray(options)) {
       this.options = {};
+    } else if (typeof options === 'object') {
+      // Deep clone to keep original object in tact
+      this.options = JSON.parse(JSON.stringify(options));
     } else {
-      this.options = options || {};
+      this.options = {};
     }
 
     this.options.test = this.options.test || /\.js($|\?)/i;


### PR DESCRIPTION
Proper deep clone, as recommended by MDN:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Deep_Clone

Use case: I found my `config.uglifyOptions` object being altered when I passed it into uglifyjs-webpack-plugin. The properties "test" and "warningsFilter" were being added. I also have processes outside of webpack that use this object and it fails as these properties are not recognized by uglify-es/js.