### PR TITLE
Restore deleted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 	<p>This plugin uses <a href="https://github.com/mishoo/UglifyJS2/tree/harmony">UglifyJS v3 </a><a href="https://npmjs.com/package/uglify-es">(`uglify-es`)</a> to minify your JavaScript<p>
 </div>
 
-> ℹ️  webpack contains the same plugin under `webpack.optimize.UglifyJsPlugin`. The documentation is valid apart from the installation instructions
+> ℹ️  webpack contains the same plugin under `webpack.optimize.UglifyJsPlugin`. This is a standalone version for those that want to control the version of UglifyJS. The documentation is valid apart from the installation instructions
 
 <h2 align="center">Install</h2>
 


### PR DESCRIPTION
Hi,

PR #61 deleted this sentence from the README which was really helpful. I found it by chance looking at tag v4.6's README.md while trying to use uglify-es with webpack. I suspect it was removed by accident, as it stated very clearly why one would use this package.
