### PR TITLE
fix(deps): cacache@10 with ISC licence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       }
     },
     "cacache": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
-      "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.0.tgz",
+      "integrity": "sha512-s9h6I9NY3KcBjfuS28K6XNmrv/HNFSzlpVD6eYMXugZg3Y8jjI1lUzTeUMa0oKByCDtHfsIy5Ec7KgWRnC5gtg==",
       "requires": {
         "bluebird": "3.5.1",
         "chownr": "1.0.1",
@@ -1342,9 +1342,19 @@
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
         "rimraf": "2.6.2",
-        "ssri": "4.1.6",
+        "ssri": "5.0.0",
         "unique-filename": "1.1.0",
         "y18n": "3.2.1"
+      },
+      "dependencies": {
+        "ssri": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+          "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "caller-path": {
@@ -8025,14 +8035,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      }
-    },
-    "ssri": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
-      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "staged-git-files": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "webpack-defaults": "webpack-defaults"
   },
   "dependencies": {
-    "cacache": "^9.2.9",
+    "cacache": "^10.0.0",
     "find-cache-dir": "^1.0.0",
     "schema-utils": "^0.3.0",
     "source-map": "^0.5.6",


### PR DESCRIPTION
Fixes: #120 

This should be able to solve the licensing issue: both `cacache` and `ssri` have been relicense to ISC (according to current npm policy), and released as a semver-major bump.

This might supersede #121 
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
