### PR TITLE
fix(compress): `options.compress` isn't assign (`webpack.optimize.UglifyJSPlugin`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class UglifyJsPlugin {
 						let ast = uglify.parse(input, {
 							filename: file
 						});
-						if(options.compress !== false) {
+						if(options.compress !== false && options.compress !== undefined) {
 							ast.figure_out_scope();
 							const compress = uglify.Compressor(options.compress || {
 								warnings: false


### PR DESCRIPTION
Issues
Fixes #146 

Comments:
This fix probably won't fix all and this will destroy compability with previous settings. The problem is that this part of code called multiple times (in my case 3 times per file): 1st time parameters == undefined, second time they're taken from webpack.config, third time == undefined. 

Now it's called 1 time, but compress config shouldn't be empty. 
`new UglifyJSPlugin({
                compress: { }
            }),`


If it is empry it probably won't run the compressor.

Hope it will help you.