### PR TITLE
fix(index): exclude is ignored (`options.exclude`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ class UglifyJsPlugin {
       sourceMap = false,
       cache = false,
       parallel = false,
+      exclude,
     } = options;
 
     this.options = {
@@ -40,6 +41,7 @@ class UglifyJsPlugin {
       sourceMap,
       cache,
       parallel,
+      exclude,
       uglifyOptions: {
         output: {
           comments: /^\**!|@preserve|@license|@cc_on/,

--- a/test/__snapshots__/exclude-option.test.js.snap
+++ b/test/__snapshots__/exclude-option.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`errors 1`] = `Array []`;
+
+exports[`errors 2`] = `Array []`;
+
+exports[`excluded1.4d3a1b43eccbc2acc9d6.js 1`] = `
+"webpackJsonp([1],[
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = function Bar1() {
+  const b = 2 + 2;
+  console.log(b + 1 + 2);
+};
+
+/***/ })
+],[0]);"
+`;
+
+exports[`excluded1.4d3a1b43eccbc2acc9d6.js 2`] = `
+"webpackJsonp([1],[
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = function Bar1() {
+  const b = 2 + 2;
+  console.log(b + 1 + 2);
+};
+
+/***/ })
+],[0]);"
+`;
+
+exports[`excluded2.a96f544a34079b25c7b4.js 1`] = `"webpackJsonp([0],[,function(o,n){o.exports=function(){console.log(7)}}],[1]);"`;
+
+exports[`excluded2.a96f544a34079b25c7b4.js 2`] = `
+"webpackJsonp([0],[
+/* 0 */,
+/* 1 */
+/***/ (function(module, exports) {
+
+module.exports = function Bar2() {
+  const b = 2 + 2;
+  console.log(b + 1 + 2);
+};
+
+/***/ })
+],[1]);"
+`;
+
+exports[`included.97bcf4abdd9efecc94b3.js 1`] = `"webpackJsonp([2],{2:function(o,n){o.exports=function(){console.log(7)}}},[2]);"`;
+
+exports[`included.97bcf4abdd9efecc94b3.js 2`] = `"webpackJsonp([2],{2:function(o,n){o.exports=function(){console.log(7)}}},[2]);"`;
+
+exports[`manifest.2264c6ca1c158d5cd90e.js 1`] = `"!function(e){function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}var r=window.webpackJsonp;window.webpackJsonp=function(t,c,a){for(var u,i,f,l=0,d=[];l<t.length;l++)i=t[l],o[i]&&d.push(o[i][0]),o[i]=0;for(u in c)Object.prototype.hasOwnProperty.call(c,u)&&(e[u]=c[u]);for(r&&r(t,c,a);d.length;)d.shift()();if(a)for(l=0;l<a.length;l++)f=n(n.s=a[l]);return f};var t={},o={3:0};n.e=function(e){function r(){u.onerror=u.onload=null,clearTimeout(i);var n=o[e];0!==n&&(n&&n[1](new Error(\\"Loading chunk \\"+e+\\" failed.\\")),o[e]=void 0)}var t=o[e];if(0===t)return new Promise(function(e){e()});if(t)return t[2];var c=new Promise(function(n,r){t=o[e]=[n,r]});t[2]=c;var a=document.getElementsByTagName(\\"head\\")[0],u=document.createElement(\\"script\\");u.type=\\"text/javascript\\",u.charset=\\"utf-8\\",u.async=!0,u.timeout=12e4,n.nc&&u.setAttribute(\\"nonce\\",n.nc),u.src=n.p+\\"\\"+e+\\".\\"+({0:\\"excluded2\\",1:\\"excluded1\\",2:\\"included\\"}[e]||e)+\\".\\"+{0:\\"a96f544a34079b25c7b4\\",1:\\"4d3a1b43eccbc2acc9d6\\",2:\\"97bcf4abdd9efecc94b3\\"}[e]+\\".js\\";var i=setTimeout(r,12e4);return u.onerror=u.onload=r,a.appendChild(u),c},n.m=e,n.c=t,n.d=function(e,r,t){n.o(e,r)||Object.defineProperty(e,r,{configurable:!1,enumerable:!0,get:t})},n.n=function(e){var r=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(r,\\"a\\",r),r},n.o=function(e,n){return Object.prototype.hasOwnProperty.call(e,n)},n.p=\\"\\",n.oe=function(e){throw console.error(e),e}}([]);"`;
+
+exports[`manifest.2264c6ca1c158d5cd90e.js 2`] = `"!function(e){function n(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,n),o.l=!0,o.exports}var r=window.webpackJsonp;window.webpackJsonp=function(t,c,a){for(var u,i,f,l=0,d=[];l<t.length;l++)i=t[l],o[i]&&d.push(o[i][0]),o[i]=0;for(u in c)Object.prototype.hasOwnProperty.call(c,u)&&(e[u]=c[u]);for(r&&r(t,c,a);d.length;)d.shift()();if(a)for(l=0;l<a.length;l++)f=n(n.s=a[l]);return f};var t={},o={3:0};n.e=function(e){function r(){u.onerror=u.onload=null,clearTimeout(i);var n=o[e];0!==n&&(n&&n[1](new Error(\\"Loading chunk \\"+e+\\" failed.\\")),o[e]=void 0)}var t=o[e];if(0===t)return new Promise(function(e){e()});if(t)return t[2];var c=new Promise(function(n,r){t=o[e]=[n,r]});t[2]=c;var a=document.getElementsByTagName(\\"head\\")[0],u=document.createElement(\\"script\\");u.type=\\"text/javascript\\",u.charset=\\"utf-8\\",u.async=!0,u.timeout=12e4,n.nc&&u.setAttribute(\\"nonce\\",n.nc),u.src=n.p+\\"\\"+e+\\".\\"+({0:\\"excluded2\\",1:\\"excluded1\\",2:\\"included\\"}[e]||e)+\\".\\"+{0:\\"a96f544a34079b25c7b4\\",1:\\"4d3a1b43eccbc2acc9d6\\",2:\\"97bcf4abdd9efecc94b3\\"}[e]+\\".js\\";var i=setTimeout(r,12e4);return u.onerror=u.onload=r,a.appendChild(u),c},n.m=e,n.c=t,n.d=function(e,r,t){n.o(e,r)||Object.defineProperty(e,r,{configurable:!1,enumerable:!0,get:t})},n.n=function(e){var r=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(r,\\"a\\",r),r},n.o=function(e,n){return Object.prototype.hasOwnProperty.call(e,n)},n.p=\\"\\",n.oe=function(e){throw console.error(e),e}}([]);"`;
+
+exports[`warnings 1`] = `Array []`;
+
+exports[`warnings 2`] = `Array []`;

--- a/test/exclude-option.test.js
+++ b/test/exclude-option.test.js
@@ -1,0 +1,64 @@
+import UglifyJsPlugin from '../src/index';
+import {
+  cleanErrorStack,
+  createCompiler,
+  compile,
+} from './helpers';
+
+describe('when applied with exclude option', () => {
+  let compiler;
+  beforeEach(() => {
+    compiler = createCompiler({
+      entry: {
+        excluded1: `${__dirname}/fixtures/excluded1.js`,
+        excluded2: `${__dirname}/fixtures/excluded2.js`,
+        included: `${__dirname}/fixtures/entry.js`,
+      },
+    });
+  });
+
+  it('matches snapshot for a single exclude', () => {
+    new UglifyJsPlugin({
+      exclude: /excluded1/,
+    }).apply(compiler);
+
+
+    return compile(compiler).then((stats) => {
+      const errors = stats.compilation.errors.map(cleanErrorStack);
+      const warnings = stats.compilation.warnings.map(cleanErrorStack);
+
+      expect(errors).toMatchSnapshot('errors');
+      expect(warnings).toMatchSnapshot('warnings');
+
+      for (const file in stats.compilation.assets) {
+        if (Object.prototype.hasOwnProperty.call(stats.compilation.assets, file)) {
+          expect(stats.compilation.assets[file].source()).toMatchSnapshot(file);
+        }
+      }
+    });
+  });
+
+  it('matches snapshot for multiple excludes', () => {
+    new UglifyJsPlugin({
+      exclude: [
+        /excluded1/,
+        /excluded2/,
+      ],
+    }).apply(compiler);
+
+
+    return compile(compiler).then((stats) => {
+      const errors = stats.compilation.errors.map(cleanErrorStack);
+      const warnings = stats.compilation.warnings.map(cleanErrorStack);
+
+      expect(errors).toMatchSnapshot('errors');
+      expect(warnings).toMatchSnapshot('warnings');
+
+      for (const file in stats.compilation.assets) {
+        if (Object.prototype.hasOwnProperty.call(stats.compilation.assets, file)) {
+          expect(stats.compilation.assets[file].source()).toMatchSnapshot(file);
+        }
+      }
+    });
+  });
+});

--- a/test/fixtures/excluded1.js
+++ b/test/fixtures/excluded1.js
@@ -1,0 +1,4 @@
+module.exports = function Bar1() {
+  const b = 2 + 2;
+  console.log(b + 1 + 2);
+};

--- a/test/fixtures/excluded2.js
+++ b/test/fixtures/excluded2.js
@@ -1,0 +1,4 @@
+module.exports = function Bar2() {
+  const b = 2 + 2;
+  console.log(b + 1 + 2);
+};


### PR DESCRIPTION
A simple demo of the problem can be found [here](https://github.com/rszewczyk/uglifyjs-webpack-plugin/tree/demo-the-problem/demo).

The expected behavior is that chunks with a filename that match the [given pattern](https://github.com/rszewczyk/uglifyjs-webpack-plugin/blob/demo-the-problem/demo/webpack.config.js#L13) will be excluded from uglify. This was the behavior exhibited by __0.4.6__. The actual behavior is that all chunks are uglified.

It looks like the problem is that the [options used to filter](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/blob/c425f3cb9612f4259af681d9c4aa1547f0d622be/src/index.js#L110) what chunks are processed, [do not include](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/blob/c425f3cb9612f4259af681d9c4aa1547f0d622be/src/index.js#L36-L49) the exclude configuration passed to the plugin constructor.