### PR TITLE
fix(index): set `maxConcurrentCallsPerWorker` to 1 (`options.parallel`)

### DIFF
--- a/src/uglify/index.js
+++ b/src/uglify/index.js
@@ -26,10 +26,8 @@ export default class {
     }
 
     if (this.maxConcurrentWorkers > 0) {
-      this.workers = workerFarm({
-        maxConcurrentWorkers: this.maxConcurrentWorkers,
-        maxConcurrentCallsPerWorker: 1,
-      }, workerFile);
+      const workerOptions = process.platform === 'win32' ? { maxConcurrentWorkers: this.maxConcurrentWorkers, maxConcurrentCallsPerWorker: 1 } : { maxConcurrentWorkers: this.maxConcurrentWorkers };
+      this.workers = workerFarm(workerOptions, workerFile);
       this.boundWorkers = (options, cb) => this.workers(JSON.stringify(options, encode), cb);
     } else {
       this.boundWorkers = (options, cb) => {

--- a/src/uglify/index.js
+++ b/src/uglify/index.js
@@ -28,6 +28,7 @@ export default class {
     if (this.maxConcurrentWorkers > 0) {
       this.workers = workerFarm({
         maxConcurrentWorkers: this.maxConcurrentWorkers,
+        maxConcurrentCallsPerWorker: 1
       }, workerFile);
       this.boundWorkers = (options, cb) => this.workers(JSON.stringify(options, encode), cb);
     } else {

--- a/src/uglify/index.js
+++ b/src/uglify/index.js
@@ -28,7 +28,7 @@ export default class {
     if (this.maxConcurrentWorkers > 0) {
       this.workers = workerFarm({
         maxConcurrentWorkers: this.maxConcurrentWorkers,
-        maxConcurrentCallsPerWorker: 1
+        maxConcurrentCallsPerWorker: 1,
       }, workerFile);
       this.boundWorkers = (options, cb) => this.workers(JSON.stringify(options, encode), cb);
     } else {


### PR DESCRIPTION
### `Issues`

- Fixes #118

### `Description`

In Windows 10 if `parallel: true` is set then the parallel worker processes can stall and the build never completes.

The minify request is successfully sent from the plugin to the dist/uglify/worker.js which then minifies the file.

The forked worker returns the result to the plugin via the Node process.send() IPC call, but the parent plugin never receives the request from the worker.
The `forked.child.on('message', this.receive.bind(this))` event in worker-farm/lib/farm.js is never invoked which causes the build to stall.

If we change the worker-farm to use `maxConcurrentCallsPerWorker: 1` it will prevent the parent from queuing multiple requests via IPC to the workers. It waits until it receives a response from the worker, then it dispatches the next file to minify. This lowers the amount of pending IPC traffic between the plugin and the workers and does not trigger the issue.

Adding this limit will mean that the worker will need to wait for the parent to receive the response before getting a new file to process, but it allows parallel processing to complete on Windows.
 
### `Notable Changes`

Changes the `worker-farm` to use `{ maxConcurrentCallsPerWorker: 1 }`.