### PR TITLE
fix: comments behavior (`options.uglifyOptions.comments/options.extractComments`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class UglifyJsPlugin {
       exclude,
       uglifyOptions: {
         output: {
-          comments: /^\**!|@preserve|@license|@cc_on/,
+          comments: false,
         },
         ...uglifyOptions,
       },

--- a/src/uglify/minify.js
+++ b/src/uglify/minify.js
@@ -20,7 +20,7 @@ const buildUglifyOptions = ({
   mangle: mangle == null ? true : mangle,
   output: {
     shebang: true,
-    comments: /^\**!|@preserve|@license|@cc_on/,
+    comments: false,
     beautify: false,
     semicolons: true,
     ...output,
@@ -37,8 +37,11 @@ const buildComments = (options, uglifyOptions, extractedComments) => {
   const condition = {};
   const commentsOpts = uglifyOptions.output.comments;
 
-  if (
-    typeof options.extractComments === 'boolean' ||
+  // /^\**!|@preserve|@license|@cc_on/
+  if (typeof options.extractComments === 'boolean') {
+    condition.preserve = commentsOpts;
+    condition.extract = /^\**!|@preserve|@license|@cc_on/;
+  } else if (
     typeof options.extractComments === 'string' ||
     options.extractComments instanceof RegExp
   ) {

--- a/test/__snapshots__/extract-comments-options.test.js.snap
+++ b/test/__snapshots__/extract-comments-options.test.js.snap
@@ -8,12 +8,7 @@ exports[`errors 3`] = `Array []`;
 
 exports[`errors 4`] = `Array []`;
 
-exports[`errors 5`] = `Array []`;
-
-exports[`test.js 1`] = `
-"/*! For license information please see test.js.LICENSE */
-var foo=1;"
-`;
+exports[`test.js 1`] = `"var foo=1;"`;
 
 exports[`test.js 2`] = `"var foo=1;"`;
 
@@ -52,10 +47,7 @@ exports[`test.license.js 1`] = `
 "
 `;
 
-exports[`test1.js 1`] = `
-"/*! For license information please see test1.js.LICENSE */
-var foo=1;"
-`;
+exports[`test1.js 1`] = `"var foo=1;"`;
 
 exports[`test1.js 2`] = `
 "/*! For license information please see test1.js.LICENSE */
@@ -68,21 +60,16 @@ var foo=1;"
 `;
 
 exports[`test1.js.LICENSE 1`] = `
-"/* Comment */
-"
-`;
-
-exports[`test1.js.LICENSE 2`] = `
 "// foo
 "
 `;
 
-exports[`test1.js.LICENSE 3`] = `
+exports[`test1.js.LICENSE 2`] = `
 "/* Comment */
 "
 `;
 
-exports[`test1.js.LICENSE 4`] = `
+exports[`test1.js.LICENSE 3`] = `
 "/* Comment */
 "
 `;
@@ -94,5 +81,3 @@ exports[`warnings 2`] = `Array []`;
 exports[`warnings 3`] = `Array []`;
 
 exports[`warnings 4`] = `Array []`;
-
-exports[`warnings 5`] = `Array []`;

--- a/test/all-options.test.js
+++ b/test/all-options.test.js
@@ -32,7 +32,6 @@ describe('when applied with all options', () => {
         mangle: false,
         output: {
           beautify: true,
-          comments: false,
         },
       },
     });
@@ -48,7 +47,6 @@ describe('when applied with all options', () => {
         mangle: false,
         output: {
           beautify: true,
-          comments: false,
         },
         warnings: true,
       },
@@ -295,7 +293,6 @@ describe('when applied with all options', () => {
                   mangle: false,
                   output: {
                     beautify: true,
-                    comments: false,
                   },
                 },
               });
@@ -349,7 +346,6 @@ describe('when applied with all options', () => {
                   mangle: false,
                   output: {
                     beautify: true,
-                    comments: false,
                   },
                 },
               });

--- a/test/ecma.test.js
+++ b/test/ecma.test.js
@@ -23,7 +23,6 @@ describe('when applied with uglifyOptions.ecma', () => {
         warnings: true,
         output: {
           beautify: true,
-          comments: false,
         },
       },
     }).apply(compiler);
@@ -60,7 +59,6 @@ describe('when applied with uglifyOptions.ecma', () => {
         warnings: true,
         output: {
           beautify: true,
-          comments: false,
         },
       },
     }).apply(compiler);
@@ -97,7 +95,6 @@ describe('when applied with uglifyOptions.ecma', () => {
         warnings: true,
         output: {
           beautify: true,
-          comments: false,
         },
       },
     }).apply(compiler);
@@ -133,7 +130,6 @@ describe('when applied with uglifyOptions.ecma', () => {
         warnings: true,
         output: {
           beautify: true,
-          comments: false,
         },
       },
     }).apply(compiler);
@@ -170,7 +166,6 @@ describe('when applied with uglifyOptions.ecma', () => {
         warnings: true,
         output: {
           beautify: true,
-          comments: false,
         },
       },
     }).apply(compiler);

--- a/test/extract-comments-options.test.js
+++ b/test/extract-comments-options.test.js
@@ -13,9 +13,6 @@ describe('when options.extractComments', () => {
     const plugin = new UglifyJsPlugin({
       uglifyOptions: {
         warnings: true,
-        output: {
-          comments: false,
-        },
         mangle: {
           properties: {
             builtins: true,
@@ -77,11 +74,6 @@ describe('when options.extractComments', () => {
     compilerEnv.context = '';
 
     const plugin = new UglifyJsPlugin({
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-      },
       extractComments: true,
     });
     plugin.apply(compilerEnv);
@@ -119,11 +111,6 @@ describe('when options.extractComments', () => {
     compilerEnv.context = '';
 
     const plugin = new UglifyJsPlugin({
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-      },
       extractComments: /foo/,
     });
     plugin.apply(compilerEnv);
@@ -161,11 +148,6 @@ describe('when options.extractComments', () => {
     compilerEnv.context = '';
 
     const plugin = new UglifyJsPlugin({
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-      },
       extractComments: 'all',
     });
     plugin.apply(compilerEnv);
@@ -204,11 +186,6 @@ describe('when options.extractComments', () => {
     compilerEnv.context = '';
 
     const plugin = new UglifyJsPlugin({
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-      },
       extractComments: () => true,
     });
     plugin.apply(compilerEnv);
@@ -247,11 +224,6 @@ describe('when options.extractComments', () => {
     compilerEnv.context = '';
 
     const plugin = new UglifyJsPlugin({
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-      },
       extractComments: {
         condition: true,
         filename(file) {

--- a/test/uglify/worker.test.js
+++ b/test/uglify/worker.test.js
@@ -6,11 +6,6 @@ describe('matches snapshot', () => {
     const options = {
       file: 'test1.js',
       input: 'var foo = 1;/* hello */',
-      uglifyOptions: {
-        output: {
-          comments: false,
-        },
-      },
       extractComments: /foo/,
     };
     worker(JSON.stringify(options, encode), (error, data) => {


### PR DESCRIPTION
Fix comments behavior:
1. by default `output.comments` should be false (https://github.com/mishoo/UglifyJS2#output-options and https://github.com/webpack/webpack/pull/5940).
2. `extractComments: true` should be interpreted as `/^\**!|@preserve|@license|@cc_on/` (https://github.com/webpack/webpack/pull/5940)

