### PR TITLE
chore(package): update `uglify-es` v3.2.0...v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "find-cache-dir": "^1.0.0",
     "schema-utils": "^0.3.0",
     "source-map": "^0.6.1",
-    "uglify-es": "^3.2.0",
+    "uglify-es": "^3.2.1",
     "webpack-sources": "^1.0.1",
     "worker-farm": "^1.4.1"
   },

--- a/test/__snapshots__/ecma.test.js.snap
+++ b/test/__snapshots__/ecma.test.js.snap
@@ -106,7 +106,7 @@ exports[`ecma 6: errors 1`] = `Array []`;
 
 exports[`ecma 6: main.js 1`] = `
 "webpackJsonp([ 0 ], [ function(module, exports) {
-    class Mortgage {
+    module.exports = class {
         constructor(principal, years, rate) {
             this.principal = principal, this.years = years, this.rate = rate;
         }
@@ -130,8 +130,7 @@ exports[`ecma 6: main.js 1`] = `
             }
             return amortization;
         }
-    }
-    module.exports = Mortgage;
+    };
 } ], [ 0 ]);"
 `;
 


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

related to this issue: https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/187

uglify-es version 3.2.0 doesn't support `const` and arrow-function. In my case, this causes build failure when I try to make a production bundle for deployment
