### PR TITLE
tests: remove `cache` directory after tests

### DIFF
--- a/test/cache-options.test.js
+++ b/test/cache-options.test.js
@@ -32,6 +32,8 @@ describe('when options.cache', () => {
 
     beforeAll(() => cacache.rm.all(cacheDir));
 
+    afterAll(() => cacache.rm.all(cacheDir));
+
     beforeEach(() => {
       const pluginEnvironment = new PluginEnvironment();
       const compilerEnv = pluginEnvironment.getEnvironmentStub();
@@ -149,6 +151,8 @@ describe('when options.cache', () => {
     let eventBinding;
 
     beforeAll(() => cacache.rm.all(cacheDir));
+
+    afterAll(() => cacache.rm.all(cacheDir));
 
     beforeEach(() => {
       const pluginEnvironment = new PluginEnvironment();
@@ -293,6 +297,8 @@ describe('when options.cache', () => {
     let eventBinding;
 
     beforeAll(() => cacache.rm.all(othercacheDir));
+
+    afterAll(() => cacache.rm.all(othercacheDir));
 
     beforeEach(() => {
       const pluginEnvironment = new PluginEnvironment();


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Remove cache after each describe, because the next test can use the previous cache. Also remove `othercacheDir` cache, because they not removed after test.