### PR TITLE
refactor(index): upgrade `compiler.plugin` to the new plugin system (`tapable`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "ci:lint": "npm run lint && npm run security",
     "ci:test": "npm run test -- --runInBand",
     "ci:coverage": "npm run test:coverage -- --runInBand",
-    "defaults": "webpack-defaults"
+    "defaults": "webpack-defaults",
+    "webpack-defaults": "webpack-defaults"
   },
   "dependencies": {
     "cacache": "^10.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -115,200 +115,208 @@ class UglifyJsPlugin {
   apply(compiler) {
     const requestShortener = new RequestShortener(compiler.context);
 
-    compiler.plugin('compilation', (compilation) => {
+    compiler.hooks.compilation.tap('UglifyJsWebpackPlugin', (compilation) => {
       if (this.options.sourceMap) {
-        compilation.plugin('build-module', (moduleArg) => {
-          // to get detailed location info about errors
-          moduleArg.useSourceMap = true;
-        });
+        compilation.hooks.buildModule.tap(
+          'UglifyJsWebpackPlugin',
+          (moduleArg) => {
+            // to get detailed location info about errors
+            moduleArg.useSourceMap = true;
+          }
+        );
       }
 
-      compilation.plugin('optimize-chunk-assets', (chunks, callback) => {
-        const uglify = new Uglify({
-          cache: this.options.cache,
-          parallel: this.options.parallel,
-        });
-        const uglifiedAssets = new WeakSet();
-        const tasks = [];
-        chunks
-          .reduce((acc, chunk) => acc.concat(chunk.files || []), [])
-          .concat(compilation.additionalChunkAssets || [])
-          .filter(ModuleFilenameHelpers.matchObject.bind(null, this.options))
-          .forEach((file) => {
-            let sourceMap;
-            const asset = compilation.assets[file];
-            if (uglifiedAssets.has(asset)) {
+      compilation.hooks.optimizeChunkAssets.tapAsync(
+        'UglifyJsWebpackPlugin',
+        (chunks, callback) => {
+          const uglify = new Uglify({
+            cache: this.options.cache,
+            parallel: this.options.parallel,
+          });
+          const uglifiedAssets = new WeakSet();
+          const tasks = [];
+          chunks
+            .reduce((acc, chunk) => acc.concat(chunk.files || []), [])
+            .concat(compilation.additionalChunkAssets || [])
+            .filter(ModuleFilenameHelpers.matchObject.bind(null, this.options))
+            .forEach((file) => {
+              let sourceMap;
+              const asset = compilation.assets[file];
+              if (uglifiedAssets.has(asset)) {
+                return;
+              }
+
+              try {
+                let input;
+                let inputSourceMap;
+
+                if (this.options.sourceMap && asset.sourceAndMap) {
+                  const { source, map } = asset.sourceAndMap();
+
+                  input = source;
+                  inputSourceMap = map;
+
+                  sourceMap = new SourceMapConsumer(inputSourceMap);
+                } else {
+                  input = asset.source();
+                  inputSourceMap = null;
+                }
+
+                // Handling comment extraction
+                let commentsFile = false;
+                if (this.options.extractComments) {
+                  commentsFile =
+                    this.options.extractComments.filename || `${file}.LICENSE`;
+                  if (typeof commentsFile === 'function') {
+                    commentsFile = commentsFile(file);
+                  }
+                }
+
+                const task = {
+                  file,
+                  input,
+                  sourceMap,
+                  inputSourceMap,
+                  commentsFile,
+                  extractComments: this.options.extractComments,
+                  uglifyOptions: this.options.uglifyOptions,
+                };
+
+                if (this.options.cache) {
+                  task.cacheKey = serialize({
+                    'uglify-es': versions.uglify,
+                    'uglifyjs-webpack-plugin': versions.plugin,
+                    'uglifyjs-webpack-plugin-options': this.options,
+                    path: compiler.outputPath
+                      ? `${compiler.outputPath}/${file}`
+                      : file,
+                    input,
+                  });
+                }
+
+                tasks.push(task);
+              } catch (error) {
+                compilation.errors.push(
+                  UglifyJsPlugin.buildError(
+                    error,
+                    file,
+                    sourceMap,
+                    compilation,
+                    requestShortener
+                  )
+                );
+              }
+            });
+
+          uglify.runTasks(tasks, (tasksError, results) => {
+            if (tasksError) {
+              compilation.errors.push(tasksError);
               return;
             }
 
-            try {
-              let input;
-              let inputSourceMap;
-
-              if (this.options.sourceMap && asset.sourceAndMap) {
-                const { source, map } = asset.sourceAndMap();
-
-                input = source;
-                inputSourceMap = map;
-
-                sourceMap = new SourceMapConsumer(inputSourceMap);
-              } else {
-                input = asset.source();
-                inputSourceMap = null;
-              }
-
-              // Handling comment extraction
-              let commentsFile = false;
-              if (this.options.extractComments) {
-                commentsFile =
-                  this.options.extractComments.filename || `${file}.LICENSE`;
-                if (typeof commentsFile === 'function') {
-                  commentsFile = commentsFile(file);
-                }
-              }
-
-              const task = {
+            results.forEach((data, index) => {
+              const {
                 file,
                 input,
                 sourceMap,
                 inputSourceMap,
                 commentsFile,
-                extractComments: this.options.extractComments,
-                uglifyOptions: this.options.uglifyOptions,
-              };
+              } = tasks[index];
+              const { error, map, code, warnings, extractedComments } = data;
 
-              if (this.options.cache) {
-                task.cacheKey = serialize({
-                  'uglify-es': versions.uglify,
-                  'uglifyjs-webpack-plugin': versions.plugin,
-                  'uglifyjs-webpack-plugin-options': this.options,
-                  path: compiler.outputPath
-                    ? `${compiler.outputPath}/${file}`
-                    : file,
-                  input,
-                });
-              }
-
-              tasks.push(task);
-            } catch (error) {
-              compilation.errors.push(
-                UglifyJsPlugin.buildError(
-                  error,
-                  file,
-                  sourceMap,
-                  compilation,
-                  requestShortener
-                )
-              );
-            }
-          });
-
-        uglify.runTasks(tasks, (tasksError, results) => {
-          if (tasksError) {
-            compilation.errors.push(tasksError);
-            return;
-          }
-
-          results.forEach((data, index) => {
-            const {
-              file,
-              input,
-              sourceMap,
-              inputSourceMap,
-              commentsFile,
-            } = tasks[index];
-            const { error, map, code, warnings, extractedComments } = data;
-
-            // Handling results
-            // Error case: add errors, and go to next file
-            if (error) {
-              compilation.errors.push(
-                UglifyJsPlugin.buildError(
-                  error,
-                  file,
-                  sourceMap,
-                  compilation,
-                  requestShortener
-                )
-              );
-              return;
-            }
-
-            let outputSource;
-            if (map) {
-              outputSource = new SourceMapSource(
-                code,
-                file,
-                JSON.parse(map),
-                input,
-                inputSourceMap
-              );
-            } else {
-              outputSource = new RawSource(code);
-            }
-
-            // Write extracted comments to commentsFile
-            if (commentsFile && extractedComments.length > 0) {
-              // Add a banner to the original file
-              if (this.options.extractComments.banner !== false) {
-                let banner =
-                  this.options.extractComments.banner ||
-                  `For license information please see ${commentsFile}`;
-                if (typeof banner === 'function') {
-                  banner = banner(commentsFile);
-                }
-                if (banner) {
-                  outputSource = new ConcatSource(
-                    `/*! ${banner} */\n`,
-                    outputSource
-                  );
-                }
-              }
-
-              const commentsSource = new RawSource(
-                `${extractedComments.join('\n\n')}\n`
-              );
-              if (commentsFile in compilation.assets) {
-                // commentsFile already exists, append new comments...
-                if (compilation.assets[commentsFile] instanceof ConcatSource) {
-                  compilation.assets[commentsFile].add('\n');
-                  compilation.assets[commentsFile].add(commentsSource);
-                } else {
-                  compilation.assets[commentsFile] = new ConcatSource(
-                    compilation.assets[commentsFile],
-                    '\n',
-                    commentsSource
-                  );
-                }
-              } else {
-                compilation.assets[commentsFile] = commentsSource;
-              }
-            }
-
-            // Updating assets
-            uglifiedAssets.add((compilation.assets[file] = outputSource));
-
-            // Handling warnings
-            if (warnings) {
-              const warnArr = UglifyJsPlugin.buildWarnings(
-                warnings,
-                file,
-                sourceMap,
-                this.options.warningsFilter,
-                requestShortener
-              );
-              if (warnArr.length > 0) {
-                compilation.warnings.push(
-                  new Error(`${file} from UglifyJs\n${warnArr.join('\n')}`)
+              // Handling results
+              // Error case: add errors, and go to next file
+              if (error) {
+                compilation.errors.push(
+                  UglifyJsPlugin.buildError(
+                    error,
+                    file,
+                    sourceMap,
+                    compilation,
+                    requestShortener
+                  )
                 );
+                return;
               }
-            }
-          });
 
-          uglify.exit();
-          callback();
-        });
-      });
+              let outputSource;
+              if (map) {
+                outputSource = new SourceMapSource(
+                  code,
+                  file,
+                  JSON.parse(map),
+                  input,
+                  inputSourceMap
+                );
+              } else {
+                outputSource = new RawSource(code);
+              }
+
+              // Write extracted comments to commentsFile
+              if (commentsFile && extractedComments.length > 0) {
+                // Add a banner to the original file
+                if (this.options.extractComments.banner !== false) {
+                  let banner =
+                    this.options.extractComments.banner ||
+                    `For license information please see ${commentsFile}`;
+                  if (typeof banner === 'function') {
+                    banner = banner(commentsFile);
+                  }
+                  if (banner) {
+                    outputSource = new ConcatSource(
+                      `/*! ${banner} */\n`,
+                      outputSource
+                    );
+                  }
+                }
+
+                const commentsSource = new RawSource(
+                  `${extractedComments.join('\n\n')}\n`
+                );
+                if (commentsFile in compilation.assets) {
+                  // commentsFile already exists, append new comments...
+                  if (
+                    compilation.assets[commentsFile] instanceof ConcatSource
+                  ) {
+                    compilation.assets[commentsFile].add('\n');
+                    compilation.assets[commentsFile].add(commentsSource);
+                  } else {
+                    compilation.assets[commentsFile] = new ConcatSource(
+                      compilation.assets[commentsFile],
+                      '\n',
+                      commentsSource
+                    );
+                  }
+                } else {
+                  compilation.assets[commentsFile] = commentsSource;
+                }
+              }
+
+              // Updating assets
+              uglifiedAssets.add((compilation.assets[file] = outputSource));
+
+              // Handling warnings
+              if (warnings) {
+                const warnArr = UglifyJsPlugin.buildWarnings(
+                  warnings,
+                  file,
+                  sourceMap,
+                  this.options.warningsFilter,
+                  requestShortener
+                );
+                if (warnArr.length > 0) {
+                  compilation.warnings.push(
+                    new Error(`${file} from UglifyJs\n${warnArr.join('\n')}`)
+                  );
+                }
+              }
+            });
+
+            uglify.exit();
+            callback();
+          });
+        }
+      );
     });
   }
 }


### PR DESCRIPTION
This PR updates `uglifyjs-webpack-plugin` to use `.tap()` and `.tapAsync()` isntaed of `.plugin()` and use the new Tapable API in `webpack@webpack/webpack#next`. 

Looks like prettier did some auto updating etc. 
