### PR TITLE
fix(package): use exact `uglify-es` version (`dependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "serialize-javascript": "^1.4.0",
     "schema-utils": "^0.3.0",
     "source-map": "^0.6.1",
-    "uglify-es": "^3.2.1",
+    "uglify-es": "3.2.2",
     "webpack-sources": "^1.0.1",
     "worker-farm": "^1.4.1"
   },


### PR DESCRIPTION
This is for fixing the uglify-es dependency, as the new 3.3.x versions breaks up all Angular builds.

See [here for Angular](https://github.com/angular/angular/issues/21173) and [here for Angular CLI](https://github.com/angular/angular-cli/issues/8997)