### PR TITLE
fix(index): invalidate cache if `dependencies` changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,10 +158,16 @@ class UglifyJsPlugin {
               if (this.options.cache) {
                 task.cacheKey = serialize({
                   'uglify-es': versions.uglify,
+                  'source-map': versions.sourceMap,
                   'uglifyjs-webpack-plugin': versions.plugin,
                   'uglifyjs-webpack-plugin-options': this.options,
                   path: compiler.outputPath ? `${compiler.outputPath}/${file}` : file,
-                  hash: crypto.createHash('md5').update(input).digest('hex'),
+                  inputHash: crypto.createHash('md5').update(
+                    input ? input.toString() : '',
+                  ).digest('hex'),
+                  inputSourceMapHash: crypto.createHash('md5').update(
+                    inputSourceMap ? inputSourceMap.toString() : '',
+                  ).digest('hex'),
                 });
               }
 

--- a/src/uglify/versions.js
+++ b/src/uglify/versions.js
@@ -1,5 +1,6 @@
 export default {
   uglify: require('uglify-es/package.json').version, // eslint-disable-line global-require
   plugin: require('../../package.json').version, // eslint-disable-line global-require
+  sourceMap: require('source-map/package.json').version, // eslint-disable-line global-require
 };
 

--- a/test/cache-options.test.js
+++ b/test/cache-options.test.js
@@ -243,7 +243,7 @@ describe('when options.cache', () => {
                     // eslint-disable-next-line no-new-func
                     const cacheEntryOptions = new Function(`'use strict'\nreturn ${cacheEntry}`)();
 
-                    expect([cacheEntryOptions.path, cacheEntryOptions.hash])
+                    expect([cacheEntryOptions.path, cacheEntryOptions.inputHash])
                       .toMatchSnapshot(`cache \`true\`: cached entry ${cacheEntryOptions.path}`);
                   });
 
@@ -389,7 +389,7 @@ describe('when options.cache', () => {
                     // eslint-disable-next-line no-new-func
                     const cacheEntryOptions = new Function(`'use strict'\nreturn ${cacheEntry}`)();
 
-                    expect([cacheEntryOptions.path, cacheEntryOptions.hash])
+                    expect([cacheEntryOptions.path, cacheEntryOptions.inputHash])
                       .toMatchSnapshot(`cache \`true\`: cached entry ${cacheEntryOptions.path}`);
                   });
 


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Today we got invalid cache (invalid source map), after upgrade `source-map` (in old version we have bug). Also in future `source-map` will upgrade and change source map, we should invalidate cache when this happens.