### PR TITLE
fix: add missing `keep_classnames`, `keep_fnames` && `safari10` options (`uglifyOptions`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Number of concurrent runs.
 |**[`output`](https://github.com/mishoo/UglifyJS2/tree/harmony#output-options)**|`{Object}`|`{}`|Additional Output Options (The defaults are optimized for best compression)|
 |**[`compress`](https://github.com/mishoo/UglifyJS2/tree/harmony#compress-options)**|`{Boolean\|Object}`|`true`|Additional Compress Options|
 |**`warnings`**|`{Boolean}`|`false`|Display Warnings|
+|**`keep_classnames`**|`{Boolean}`|`undefined`|Prevent discarding or mangling of class names|
+|**`keep_fnames`**|`{Boolean}`|`false`|Prevent discarding or mangling of function names|
+|**`safari10`**|`{Boolean}`|`false`|Enable work around Safari 10/11 bugs in loop scoping and await|
 
 **webpack.config.js**
 ```js
@@ -188,7 +191,10 @@ Number of concurrent runs.
         ...options
       },
       compress: {...options},
-      warnings: false
+      warnings: false,
+      keep_classnames: false,
+      keep_fnames: false,
+      safari10: false
     }
   })
 ]

--- a/src/options.json
+++ b/src/options.json
@@ -59,6 +59,15 @@
         },
         "nameCache": {
           "type": ["object", "null"]
+        },
+        "keep_classnames": {
+          "type": "boolean"
+        },
+        "keep_fnames": {
+          "type": "boolean"
+        },
+        "safari10": {
+          "type": "boolean"
         }
       }
     }

--- a/src/uglify/minify.js
+++ b/src/uglify/minify.js
@@ -13,6 +13,11 @@ const buildUglifyOptions = ({
   warnings,
   toplevel,
   nameCache,
+  // eslint-disable-next-line camelcase
+  keep_classnames,
+  // eslint-disable-next-line camelcase
+  keep_fnames,
+  safari10,
 } = {}) => ({
   ie8,
   ecma,
@@ -31,6 +36,9 @@ const buildUglifyOptions = ({
   nameCache,
   // Ignoring sourcemap from options
   sourceMap: null,
+  keep_classnames,
+  keep_fnames,
+  safari10,
 });
 
 const buildComments = (options, uglifyOptions, extractedComments) => {

--- a/test/uglify/__snapshots__/worker.test.js.snap
+++ b/test/uglify/__snapshots__/worker.test.js.snap
@@ -59,3 +59,33 @@ Object {
   "warnings": undefined,
 }
 `;
+
+exports[`test7.js 1`] = `
+Object {
+  "code": "function foo(){return function bar(){return a}()}",
+  "error": undefined,
+  "extractedComments": Array [],
+  "map": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`test8.js 1`] = `
+Object {
+  "code": "function foo(){return class Component{}}",
+  "error": undefined,
+  "extractedComments": Array [],
+  "map": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`test9.js 1`] = `
+Object {
+  "code": "function f(o){for(let f of a)console.log(f)}",
+  "error": undefined,
+  "extractedComments": Array [],
+  "map": undefined,
+  "warnings": undefined,
+}
+`;

--- a/test/uglify/worker.test.js
+++ b/test/uglify/worker.test.js
@@ -116,4 +116,57 @@ describe('matches snapshot', () => {
       expect(data).toMatchSnapshot(options.file);
     });
   });
+
+  it('when uglifyOptions.keep_fnames is enabled', () => {
+    const options = {
+      file: 'test7.js',
+      input: 'function foo(){ return function bar() { return a; }(); }',
+      uglifyOptions: {
+        keep_fnames: true,
+      },
+    };
+
+    worker(serialize(options), (error, data) => {
+      if (error) {
+        throw error;
+      }
+      expect(data).toMatchSnapshot(options.file);
+      expect(data.code).toEqual(expect.stringContaining('bar'));
+    });
+  });
+
+  it('when uglifyOptions.keep_classnames is enabled', () => {
+    const options = {
+      file: 'test8.js',
+      input: 'function foo(){ return class Component { }; }',
+      uglifyOptions: {
+        keep_classnames: true,
+      },
+    };
+
+    worker(serialize(options), (error, data) => {
+      if (error) {
+        throw error;
+      }
+      expect(data).toMatchSnapshot(options.file);
+      expect(data.code).toEqual(expect.stringContaining('Component'));
+    });
+  });
+
+  it('when uglifyOptions.safari10 is enabled', () => {
+    const options = {
+      file: 'test9.js',
+      input: 'function f(o) { for (let n of a) { console.log(n); } }',
+      uglifyOptions: {
+        safari10: true,
+      },
+    };
+
+    worker(serialize(options), (error, data) => {
+      if (error) {
+        throw error;
+      }
+      expect(data).toMatchSnapshot(options.file);
+    });
+  });
 });


### PR DESCRIPTION
There are omited top-level options `keep_classnames`, `keep_fnames` and `safari10` for uglify-js. I believe we should be able to use all options supported by underlying minification package.
