### PR TITLE
feat(minify): extract `LICENSE && Copyright` comments by default (`options.extractComments`)

### DIFF
--- a/src/uglify/minify.js
+++ b/src/uglify/minify.js
@@ -40,7 +40,7 @@ const buildComments = (options, uglifyOptions, extractedComments) => {
   // /^\**!|@preserve|@license|@cc_on/
   if (typeof options.extractComments === 'boolean') {
     condition.preserve = commentsOpts;
-    condition.extract = /Copyright|LICENSE|@preserve|@license|@cc_on/ig;
+    condition.extract = /^\**!Copyright|LICENSE|@preserve|@license|@cc_on/ig;
   } else if (
     typeof options.extractComments === 'string' ||
     options.extractComments instanceof RegExp

--- a/src/uglify/minify.js
+++ b/src/uglify/minify.js
@@ -40,7 +40,7 @@ const buildComments = (options, uglifyOptions, extractedComments) => {
   // /^\**!|@preserve|@license|@cc_on/
   if (typeof options.extractComments === 'boolean') {
     condition.preserve = commentsOpts;
-    condition.extract = /^\**!Copyright|LICENSE|@preserve|@license|@cc_on/ig;
+    condition.extract = /^\**!|Copyright|LICENSE|@preserve|@license|@cc_on/ig;
   } else if (
     typeof options.extractComments === 'string' ||
     options.extractComments instanceof RegExp

--- a/src/uglify/minify.js
+++ b/src/uglify/minify.js
@@ -40,7 +40,7 @@ const buildComments = (options, uglifyOptions, extractedComments) => {
   // /^\**!|@preserve|@license|@cc_on/
   if (typeof options.extractComments === 'boolean') {
     condition.preserve = commentsOpts;
-    condition.extract = /^\**!|@preserve|@license|@cc_on/;
+    condition.extract = /Copyright|LICENSE|@preserve|@license|@cc_on/ig;
   } else if (
     typeof options.extractComments === 'string' ||
     options.extractComments instanceof RegExp


### PR DESCRIPTION
This is the regex we've been using in our builds and it's been successfully grabbing more of the license headers.