### PR TITLE
fix(index): correct `[name].js.LICENSE` file path (`options.extractComments`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
   no-param-reassign
 */
 import crypto from 'crypto';
+import path from 'path';
 import { SourceMapConsumer } from 'source-map';
 import { SourceMapSource, RawSource, ConcatSource } from 'webpack-sources';
 import RequestShortener from 'webpack/lib/RequestShortener';
@@ -211,7 +212,8 @@ class UglifyJsPlugin {
           if (commentsFile && extractedComments.length > 0) {
             // Add a banner to the original file
             if (this.options.extractComments.banner !== false) {
-              let banner = this.options.extractComments.banner || `For license information please see ${commentsFile}`;
+              let banner = this.options.extractComments.banner
+                || `For license information please see ${path.posix.basename(commentsFile)}`;
 
               if (typeof banner === 'function') {
                 banner = banner(commentsFile);

--- a/test/__snapshots__/extract-comments-options.test.js.snap
+++ b/test/__snapshots__/extract-comments-options.test.js.snap
@@ -8,6 +8,28 @@ exports[`errors 3`] = `Array []`;
 
 exports[`errors 4`] = `Array []`;
 
+exports[`errors 5`] = `Array []`;
+
+exports[`nested/nested/test1.js 1`] = `
+"/*! For license information please see test1.js.LICENSE */
+var foo=1;"
+`;
+
+exports[`nested/nested/test1.js.LICENSE 1`] = `
+"/* Comment */
+"
+`;
+
+exports[`nested/test.js 1`] = `
+"/*! For license information please see test.js.LICENSE */
+var foo=1;"
+`;
+
+exports[`nested/test1.js.LICENSE 1`] = `
+"// Comment
+"
+`;
+
 exports[`test.js 1`] = `"var foo=1;"`;
 
 exports[`test.js 2`] = `"var foo=1;"`;
@@ -81,3 +103,5 @@ exports[`warnings 2`] = `Array []`;
 exports[`warnings 3`] = `Array []`;
 
 exports[`warnings 4`] = `Array []`;
+
+exports[`warnings 5`] = `Array []`;


### PR DESCRIPTION
### `Issues`

- Fixes #181

### `Notable Changes`

license path right now always relative to file where from extract
