### PR TITLE
fix(package): update`cacache` v10.0.1...10.0.4 (`dependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack-defaults": "webpack-defaults"
   },
   "dependencies": {
-    "cacache": "^10.0.1",
+    "cacache": "^10.0.4",
     "find-cache-dir": "^1.0.0",
     "serialize-javascript": "^1.4.0",
     "schema-utils": "^0.4.2",


### PR DESCRIPTION
### `Issues`

- Fixes https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/246

### `Notable Changes`

On the 10.0.4 version of cacache, ssri was upgraded, where was resolved the vulnerability