### PR TITLE
fix(index): correct default asset name `{RegExp}` (`options.test`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ class UglifyJsPlugin {
 
     const {
       uglifyOptions = {},
-      test = /\.(js?)(\?.+)?$/i,
+      test = /\.js(\?.*)?$/i,
       warningsFilter = () => true,
       extractComments = false,
       sourceMap = false,


### PR DESCRIPTION
https://regex101.com/r/SJm7SO/2

### `Reference`

https://github.com/webpack-contrib/uglifyjs-webpack-plugin/pull/251#issuecomment-372731973