### PR TITLE
refactor: push each `warning` separately

### DIFF
--- a/test/__snapshots__/all-options.test.js.snap
+++ b/test/__snapshots__/all-options.test.js.snap
@@ -57,7 +57,6 @@ exports[`when applied with all options matches snapshot: manifest.d6857f782c13a9
 
 exports[`when applied with all options matches snapshot: warnings 1`] = `
 Array [
-  "Error: main.0c220ec66316af2c1b24.js from UglifyJs
-Dropping unused variable a [./test/fixtures/entry.js:4,0]",
+  "Dropping unused variable a [./test/fixtures/entry.js:4,0]",
 ]
 `;


### PR DESCRIPTION
Just refactor. Each warning should be push separately, it is allow filter some warning after uglify plugin from `compilation.warnings`, also it is improve readability warning, `stack` in one line looks horrible