### PR TITLE
Don't use a worker farm unless more than one process is required

### DIFF
--- a/src/uglify/index.js
+++ b/src/uglify/index.js
@@ -25,7 +25,7 @@ export default class {
       return;
     }
 
-    if (this.maxConcurrentWorkers > 0) {
+    if (this.maxConcurrentWorkers > 1) {
       const workerOptions = process.platform === 'win32' ? { maxConcurrentWorkers: this.maxConcurrentWorkers, maxConcurrentCallsPerWorker: 1 } : { maxConcurrentWorkers: this.maxConcurrentWorkers };
       this.workers = workerFarm(workerOptions, workerFile);
       this.boundWorkers = (options, cb) => this.workers(serialize(options), cb);


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

This should save some memory due to sharing common data within one process instead of spawning a second one.