### PR TITLE
perf(src/index): regression caused by parsing source maps individually

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,18 +48,11 @@ class UglifyJsPlugin {
         ...uglifyOptions,
       },
     };
-    this.sourceMapsCache = new WeakMap();
   }
 
-  buildError(err, file, inputSourceMap, requestShortener) {
+  static buildError(err, file, sourceMap, requestShortener) {
     // Handling error which should have line, col, filename and message
     if (err.line) {
-      const sourceMapCacheKey = { file };
-      let sourceMap = this.sourceMapsCache.get(sourceMapCacheKey);
-      if (!sourceMap) {
-        sourceMap = new SourceMapConsumer(inputSourceMap);
-        this.sourceMapsCache.set(sourceMapCacheKey, sourceMap);
-      }
       const original = sourceMap && sourceMap.originalPositionFor({
         line: err.line,
         column: err.col,
@@ -74,18 +67,9 @@ class UglifyJsPlugin {
     return new Error(`${file} from UglifyJs\n${err.message}`);
   }
 
-  buildWarning(warning, file, inputSourceMap, warningsFilter, requestShortener) {
-    if (!file || !inputSourceMap) {
+  static buildWarning(warning, file, sourceMap, warningsFilter, requestShortener) {
+    if (!file || !sourceMap) {
       return warning;
-    }
-
-    const sourceMapCacheKey = { file };
-
-    let sourceMap = this.sourceMapsCache.get(sourceMapCacheKey);
-
-    if (!sourceMap) {
-      sourceMap = new SourceMapConsumer(inputSourceMap);
-      this.sourceMapsCache.set(sourceMapCacheKey, sourceMap);
     }
 
     const match = warningRegex.exec(warning);
@@ -187,11 +171,15 @@ class UglifyJsPlugin {
 
             tasks.push(task);
           } catch (error) {
+            let sourceMap = null;
+            if (inputSourceMap && utils.isSourceMap(inputSourceMap)) {
+              sourceMap = new SourceMapConsumer(inputSourceMap);
+            }
             compilation.errors.push(
-              this.buildError(
+              UglifyJsPlugin.buildError(
                 error,
                 file,
-                inputSourceMap,
+                sourceMap,
                 requestShortener,
               ),
             );
@@ -208,14 +196,20 @@ class UglifyJsPlugin {
           const { file, input, inputSourceMap, commentsFile } = tasks[index];
           const { error, map, code, warnings, extractedComments } = data;
 
+          // Create source map if needed
+          let sourceMap = null;
+          if (inputSourceMap && utils.isSourceMap(inputSourceMap) && (error || (warnings && warnings.length > 0))) {
+            sourceMap = new SourceMapConsumer(inputSourceMap);
+          }
+
           // Handling results
           // Error case: add errors, and go to next file
           if (error) {
             compilation.errors.push(
-              this.buildError(
+              UglifyJsPlugin.buildError(
                 error,
                 file,
-                inputSourceMap,
+                sourceMap,
                 requestShortener,
               ),
             );
@@ -275,10 +269,10 @@ class UglifyJsPlugin {
           // Handling warnings
           if (warnings && warnings.length > 0) {
             warnings.forEach((warning) => {
-              const builtWarning = this.buildWarning(
+              const builtWarning = UglifyJsPlugin.buildWarning(
                 warning,
                 file,
-                inputSourceMap,
+                sourceMap,
                 this.options.warningsFilter,
                 requestShortener,
               );


### PR DESCRIPTION
See issue #286 

This approach reverts to not using a separate cache object, but being careful about lazily instantiating the `SourceMapConsumer` only when we know it is needed.

In my project's build, this took the number of instantiated `SourceMapConsumer` objects from 1418 down to 21.
