### PR TITLE
feature: add support for additional cache keys option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module.exports = {
 |**`include`**|`{RegExp\|Array<RegExp>}`|`undefined`|Files to `include`|
 |**`exclude`**|`{RegExp\|Array<RegExp>}`|`undefined`|Files to `exclude`|
 |**`cache`**|`{Boolean\|String}`|`false`|Enable file caching|
+|**`additionalCacheKeys`**|`{Object}`|`{}`|Add additional keys to the default cache key generator|
 |**`parallel`**|`{Boolean\|Number}`|`false`|Use multi-process parallel running to improve the build speed|
 |**`sourceMap`**|`{Boolean}`|`false`|Use source maps to map error message locations to modules (This slows down the compilation) ⚠️ **`cheap-source-map` options don't work with this plugin**|
 |**`uglifyOptions`**|`{Object}`|[`{...defaults}`](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/tree/master#uglifyoptions)|`uglify` [Options](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options)|
@@ -111,6 +112,35 @@ Default path to cache directory: `node_modules/.cache/uglifyjs-webpack-plugin`.
 ```
 
 Path to cache directory.
+
+### `additionalCacheKeys`
+
+#### `{Object}`
+
+**webpack.config.js**
+```js
+[
+  new UglifyJsPlugin({
+    cache: true,
+    additionalCacheKeys: {
+      myCustomKey: 'myCustomValue',
+    }
+  })
+]
+```
+
+Add additional keys to the default cache key generator.
+
+Default keys:
+```js
+{
+  'uglify-es': versions.uglify, // uglify version
+  'uglifyjs-webpack-plugin': versions.plugin, // plugin version
+  'uglifyjs-webpack-plugin-options': this.options, // plugin options
+  path: compiler.outputPath ? `${compiler.outputPath}/${file}` : file, // asset path
+  hash: crypto.createHash('md4').update(input).digest('hex'), // source file hash
+}
+```
 
 ### `parallel`
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ class UglifyJsPlugin {
       extractComments = false,
       sourceMap = false,
       cache = false,
+      additionalCacheKeys = {},
       parallel = false,
       include,
       exclude,
@@ -38,6 +39,7 @@ class UglifyJsPlugin {
       extractComments,
       sourceMap,
       cache,
+      additionalCacheKeys,
       parallel,
       include,
       exclude,
@@ -182,6 +184,7 @@ class UglifyJsPlugin {
                 'uglifyjs-webpack-plugin-options': this.options,
                 path: compiler.outputPath ? `${compiler.outputPath}/${file}` : file,
                 hash: crypto.createHash('md4').update(input).digest('hex'),
+                ...this.options.additionalCacheKeys,
               });
             }
 

--- a/src/options.json
+++ b/src/options.json
@@ -10,6 +10,10 @@
         { "type": "string" }
       ]
     },
+    "additionalCacheKeys": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "parallel": {
       "oneOf": [
         { "type": "boolean" },

--- a/test/__snapshots__/cache-options.test.js.snap
+++ b/test/__snapshots__/cache-options.test.js.snap
@@ -79,3 +79,39 @@ exports[`when options.cache true matches snapshot: main.0c220ec66316af2c1b24.js 
 exports[`when options.cache true matches snapshot: manifest.d6857f782c13a99b5917.js 1`] = `"!function(r){var n=window.webpackJsonp;window.webpackJsonp=function(e,u,c){for(var f,i,p,a=0,l=[];a<e.length;a++)i=e[a],o[i]&&l.push(o[i][0]),o[i]=0;for(f in u)Object.prototype.hasOwnProperty.call(u,f)&&(r[f]=u[f]);for(n&&n(e,u,c);l.length;)l.shift()();if(c)for(a=0;a<c.length;a++)p=t(t.s=c[a]);return p};var e={},o={1:0};function t(n){if(e[n])return e[n].exports;var o=e[n]={i:n,l:!1,exports:{}};return r[n].call(o.exports,o,o.exports,t),o.l=!0,o.exports}t.m=r,t.c=e,t.d=function(r,n,e){t.o(r,n)||Object.defineProperty(r,n,{configurable:!1,enumerable:!0,get:e})},t.n=function(r){var n=r&&r.__esModule?function(){return r.default}:function(){return r};return t.d(n,\\"a\\",n),n},t.o=function(r,n){return Object.prototype.hasOwnProperty.call(r,n)},t.p=\\"\\",t.oe=function(r){throw console.error(r),r}}([]);"`;
 
 exports[`when options.cache true matches snapshot: warnings 1`] = `Array []`;
+
+exports[`when options.cache when options.additionalCacheKeys compilation handler when called optimize-chunk-assets handler cache files: test.js 1`] = `
+Array [
+  "test.js",
+  "28e4d31993a4f0bf5420d06d6e6013b8",
+]
+`;
+
+exports[`when options.cache when options.additionalCacheKeys compilation handler when called optimize-chunk-assets handler cache files: test1.js 1`] = `
+Array [
+  "test1.js",
+  "0ee8d6a0ecdd7bc2322d1e726ef41cdd",
+]
+`;
+
+exports[`when options.cache when options.additionalCacheKeys compilation handler when called optimize-chunk-assets handler cache files: test2.js 1`] = `
+Array [
+  "test2.js",
+  "ba96de0d701dab1af6ca647f97d42fb7",
+]
+`;
+
+exports[`when options.cache when options.additionalCacheKeys compilation handler when called optimize-chunk-assets handler cache files: test3.js 1`] = `
+Array [
+  "test3.js",
+  "ef8b436e106d1bbfe07b50263e91deac",
+]
+`;
+
+exports[`when options.cache when options.additionalCacheKeys matches snapshot: errors 1`] = `Array []`;
+
+exports[`when options.cache when options.additionalCacheKeys matches snapshot: main.0c220ec66316af2c1b24.js 1`] = `"webpackJsonp([0],[function(o,n){o.exports=function(){console.log(7)}}],[0]);"`;
+
+exports[`when options.cache when options.additionalCacheKeys matches snapshot: manifest.d6857f782c13a99b5917.js 1`] = `"!function(r){var n=window.webpackJsonp;window.webpackJsonp=function(e,u,c){for(var f,i,p,a=0,l=[];a<e.length;a++)i=e[a],o[i]&&l.push(o[i][0]),o[i]=0;for(f in u)Object.prototype.hasOwnProperty.call(u,f)&&(r[f]=u[f]);for(n&&n(e,u,c);l.length;)l.shift()();if(c)for(a=0;a<c.length;a++)p=t(t.s=c[a]);return p};var e={},o={1:0};function t(n){if(e[n])return e[n].exports;var o=e[n]={i:n,l:!1,exports:{}};return r[n].call(o.exports,o,o.exports,t),o.l=!0,o.exports}t.m=r,t.c=e,t.d=function(r,n,e){t.o(r,n)||Object.defineProperty(r,n,{configurable:!1,enumerable:!0,get:e})},t.n=function(r){var n=r&&r.__esModule?function(){return r.default}:function(){return r};return t.d(n,\\"a\\",n),n},t.o=function(r,n){return Object.prototype.hasOwnProperty.call(r,n)},t.p=\\"\\",t.oe=function(r){throw console.error(r),r}}([]);"`;
+
+exports[`when options.cache when options.additionalCacheKeys matches snapshot: warnings 1`] = `Array []`;

--- a/test/__snapshots__/invalid-options.test.js.snap
+++ b/test/__snapshots__/invalid-options.test.js.snap
@@ -154,53 +154,53 @@ options.cache should match exactly one schema in oneOf
 exports[`when applied with invalid options throws validation errors 3`] = `
 "UglifyJs Plugin Invalid Options
 
-options.parallel should be boolean
-options.parallel should be integer
-options.parallel should match exactly one schema in oneOf
+options.additionalCacheKeys should be object
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 4`] = `
 "UglifyJs Plugin Invalid Options
 
-options.parallel should be boolean
-options.parallel should be integer
-options.parallel should match exactly one schema in oneOf
+options.additionalCacheKeys should be object
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 5`] = `
 "UglifyJs Plugin Invalid Options
 
-options.sourceMap should be boolean
+options.parallel should be boolean
+options.parallel should be integer
+options.parallel should match exactly one schema in oneOf
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 6`] = `
 "UglifyJs Plugin Invalid Options
 
-options.uglifyOptions should be object
+options.parallel should be boolean
+options.parallel should be integer
+options.parallel should match exactly one schema in oneOf
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 7`] = `
 "UglifyJs Plugin Invalid Options
 
-options.uglifyOptions.ie8 should be boolean
+options.sourceMap should be boolean
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 8`] = `
 "UglifyJs Plugin Invalid Options
 
-options.uglifyOptions.ecma should be integer
+options.uglifyOptions should be object
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 9`] = `
 "UglifyJs Plugin Invalid Options
 
-options.uglifyOptions.ecma should be integer
+options.uglifyOptions.ie8 should be boolean
 "
 `;
 
@@ -214,11 +214,25 @@ options.uglifyOptions.ecma should be integer
 exports[`when applied with invalid options throws validation errors 11`] = `
 "UglifyJs Plugin Invalid Options
 
-options.uglifyOptions.ecma should be >= 5
+options.uglifyOptions.ecma should be integer
 "
 `;
 
 exports[`when applied with invalid options throws validation errors 12`] = `
+"UglifyJs Plugin Invalid Options
+
+options.uglifyOptions.ecma should be integer
+"
+`;
+
+exports[`when applied with invalid options throws validation errors 13`] = `
+"UglifyJs Plugin Invalid Options
+
+options.uglifyOptions.ecma should be >= 5
+"
+`;
+
+exports[`when applied with invalid options throws validation errors 14`] = `
 "UglifyJs Plugin Invalid Options
 
 options.uglifyOptions.ecma should be <= 8

--- a/test/invalid-options.test.js
+++ b/test/invalid-options.test.js
@@ -55,6 +55,18 @@ describe('when applied with invalid options', () => {
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
+      new UglifyJsPlugin({ additionalCacheKeys: false });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      new UglifyJsPlugin({ additionalCacheKeys: 'additional-cache-key' });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      new UglifyJsPlugin({ additionalCacheKeys: { path: 'path/to/output' } });
+    }).not.toThrow('Validation Error');
+
+    expect(() => {
       new UglifyJsPlugin({ parallel: true });
     }).not.toThrow('Validation Error');
 


### PR DESCRIPTION
PR for issue #303 

This adds an option for user to pass additional keys to the default cache key generator for more customization, allowing the user to have more control, if needed, over what hits/misses in the cache.
