### PR TITLE
fix: return missing important information

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ class UglifyJsPlugin {
       }
     }
 
-    return warningMessage;
+    return `UglifyJs Plugin: ${warningMessage} in ${file}`;
   }
 
   apply(compiler) {

--- a/test/__snapshots__/all-options.test.js.snap
+++ b/test/__snapshots__/all-options.test.js.snap
@@ -57,6 +57,6 @@ exports[`when applied with all options matches snapshot: manifest.d6857f782c13a9
 
 exports[`when applied with all options matches snapshot: warnings 1`] = `
 Array [
-  "Dropping unused variable a [./test/fixtures/entry.js:4,0]",
+  "UglifyJs Plugin: Dropping unused variable a [./test/fixtures/entry.js:4,0] in main.0c220ec66316af2c1b24.js",
 ]
 `;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

fixes #281  

> Before: single warning for an asset, After: each warning separate
Before: info about the asset, After: information missing
Before: note about UglifyJS, After: no info

1. Each warning separate, it is allow filtering `compilation.warning` for plugins and who run webpack using own script (i have many questions in gitter how it is better do and one warning on an assets is best solution)
2. Add information about the asset
3. Add information about `UglifyJS`