### PR TITLE
fix(uglify/Runner): prevent errors on limited shells where `os.cpus` returns `undefined`

### DIFF
--- a/src/uglify/Runner.js
+++ b/src/uglify/Runner.js
@@ -16,7 +16,10 @@ export default class Runner {
   constructor(options = {}) {
     const { cache, parallel } = options;
     this.cacheDir = cache === true ? findCacheDir({ name: 'uglifyjs-webpack-plugin' }) : cache;
-    this.maxConcurrentWorkers = parallel === true ? os.cpus().length - 1 : Math.min(Number(parallel) || 0, os.cpus().length - 1);
+    // https://github.com/nodejs/node/issues/19022
+    // in some cases cpus() returns undefined
+    const cpusLength = (os.cpus() ? os.cpus().length : 1);
+    this.maxConcurrentWorkers = parallel === true ? cpusLength - 1 : Math.min(Number(parallel) || 0, cpusLength - 1);
   }
 
   runTasks(tasks, callback) {

--- a/src/uglify/Runner.js
+++ b/src/uglify/Runner.js
@@ -18,7 +18,7 @@ export default class Runner {
     this.cacheDir = cache === true ? findCacheDir({ name: 'uglifyjs-webpack-plugin' }) : cache;
     // https://github.com/nodejs/node/issues/19022
     // in some cases cpus() returns undefined
-    const cpusLength = (os.cpus() ? os.cpus().length : 1);
+    const cpusLength = (os.cpus() || { length: 1 }).length;
     this.maxConcurrentWorkers = parallel === true ? cpusLength - 1 : Math.min(Number(parallel) || 0, cpusLength - 1);
   }
 


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
