### PR TITLE
fix(uglify/Runner): `cpus` length in a chroot environment (`os.cpus()`)

### DIFF
--- a/src/uglify/Runner.js
+++ b/src/uglify/Runner.js
@@ -16,7 +16,10 @@ export default class Runner {
   constructor(options = {}) {
     const { cache, parallel } = options;
     this.cacheDir = cache === true ? findCacheDir({ name: 'uglifyjs-webpack-plugin' }) : cache;
-    this.maxConcurrentWorkers = parallel === true ? os.cpus().length - 1 : Math.min(Number(parallel) || 0, os.cpus().length - 1);
+    // In some cases cpus() returns undefined
+    // https://github.com/nodejs/node/issues/19022
+    const cpus = (os.cpus() || { length: 1 });
+    this.maxConcurrentWorkers = parallel === true ? cpus.length - 1 : Math.min(Number(parallel) || 0, cpus.length - 1);
   }
 
   runTasks(tasks, callback) {


### PR DESCRIPTION
### `Issues`

- Fixes #337
- Closes #338 