### PR TITLE
feat: support passing context object to minify function option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ module.exports = {
 |**`parallel`**|`{Boolean\|Number}`|`false`|Use multi-process parallel running to improve the build speed|
 |**`sourceMap`**|`{Boolean}`|`false`|Use source maps to map error message locations to modules (This slows down the compilation) ⚠️ **`cheap-source-map` options don't work with this plugin**|
 |**`minify`**|`{Function}`|`undefined`|Allows you to override default minify function|
+|**`minifyContext`**|{Object}|`undefined`|Allows passing contextual information to the minify function.  Useful in combination with `parallel`.  The object must be serializable.
 |**`uglifyOptions`**|`{Object}`|[`{...defaults}`](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/tree/master#uglifyoptions)|`uglify` [Options](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options)|
 |**`extractComments`**|`{Boolean\|RegExp\|Function<(node, comment) -> {Boolean\|Object}>}`|`false`|Whether comments shall be extracted to a separate file, (see [details](https://github.com/webpack/webpack/commit/71933e979e51c533b432658d5e37917f9e71595a) (`webpack >= 2.3.0`)|
 |**`warningsFilter`**|`{Function(source) -> {Boolean}}`|`() => true`|Allow to filter uglify warnings|
@@ -128,7 +129,7 @@ Path to cache directory.
     cache: true,
     cacheKeys: (defaultCacheKeys, file) => {
       defaultCacheKeys.myCacheKey = 'myCacheKeyValue';
-      
+
       return defaultCacheKeys;
     },
   })
@@ -206,7 +207,7 @@ If you use your own `minify` function please read the `minify` section for handl
        const extractedComments = [];
 
        // Custom logic for extract comments
-      
+
        const { error, map, code, warnings } = require('uglify-module') // Or require('./path/to/uglify-module')
          .minify(
            file,

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ class UglifyJsPlugin {
       cache = false,
       cacheKeys = defaultCacheKeys => defaultCacheKeys,
       parallel = false,
+      minifyContext,
       include,
       exclude,
     } = options;
@@ -42,6 +43,7 @@ class UglifyJsPlugin {
       include,
       exclude,
       minify,
+      minifyContext,
       uglifyOptions: {
         compress: {
           inline: 1,
@@ -189,6 +191,7 @@ class UglifyJsPlugin {
               extractComments: this.options.extractComments,
               uglifyOptions: this.options.uglifyOptions,
               minify: this.options.minify,
+              minifyContext: this.options.minifyContext,
             };
 
             if (this.options.cache) {

--- a/src/options.json
+++ b/src/options.json
@@ -25,6 +25,7 @@
     "minify": {
       "instanceof": "Function"
     },
+    "minifyContext": {},
     "uglifyOptions": {
       "additionalProperties": true,
       "type": "object",

--- a/src/uglify/minify.js
+++ b/src/uglify/minify.js
@@ -127,10 +127,17 @@ const buildComments = (options, uglifyOptions, extractedComments) => {
 };
 
 const minify = (options) => {
-  const { file, input, inputSourceMap, extractComments, minify: minifyFn } = options;
+  const {
+    file,
+    input,
+    inputSourceMap,
+    extractComments,
+    minify: minifyFn,
+    minifyContext,
+  } = options;
 
   if (minifyFn) {
-    return minifyFn({ [file]: input }, inputSourceMap);
+    return minifyFn({ [file]: input }, inputSourceMap, minifyContext);
   }
 
   // Copy uglify options

--- a/test/__snapshots__/minify-option.test.js.snap
+++ b/test/__snapshots__/minify-option.test.js.snap
@@ -221,6 +221,14 @@ Object {
 
 exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier and \`sourceMap\` is \`true\`: warnings 1`] = `Array []`;
 
+exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier using context: errors 1`] = `Array []`;
+
+exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier using context: main.js 1`] = `"webpackJsonp([0],[function(t,e,s){\\"use strict\\";Object.defineProperty(e,\\"__esModule\\",{value:!0});e.default=class{constructor(t,e){this.x=t,this.y=e}static distance(t,e){const s=t.x-e.x,c=t.y-e.y;return Math.hypot(s,c)}}}],[0]);"`;
+
+exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier using context: manifest.js 1`] = `"!function(r){var n=window.webpackJsonp;window.webpackJsonp=function(e,u,c){for(var f,i,p,a=0,l=[];a<e.length;a++)i=e[a],o[i]&&l.push(o[i][0]),o[i]=0;for(f in u)Object.prototype.hasOwnProperty.call(u,f)&&(r[f]=u[f]);for(n&&n(e,u,c);l.length;)l.shift()();if(c)for(a=0;a<c.length;a++)p=t(t.s=c[a]);return p};var e={},o={1:0};function t(n){if(e[n])return e[n].exports;var o=e[n]={i:n,l:!1,exports:{}};return r[n].call(o.exports,o,o.exports,t),o.l=!0,o.exports}t.m=r,t.c=e,t.d=function(r,n,e){t.o(r,n)||Object.defineProperty(r,n,{configurable:!1,enumerable:!0,get:e})},t.n=function(r){var n=r&&r.__esModule?function(){return r.default}:function(){return r};return t.d(n,\\"a\\",n),n},t.o=function(r,n){return Object.prototype.hasOwnProperty.call(r,n)},t.p=\\"\\",t.oe=function(r){throw console.error(r),r}}([]);"`;
+
+exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier using context: warnings 1`] = `Array []`;
+
 exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier: errors 1`] = `Array []`;
 
 exports[`when applied with \`minify\` option matches snapshot for \`terser\` minifier: main.js 1`] = `"webpackJsonp([0],[function(t,e,s){\\"use strict\\";Object.defineProperty(e,\\"__esModule\\",{value:!0});e.default=class{constructor(t,e){this.x=t,this.y=e}static distance(t,e){const s=t.x-e.x,c=t.y-e.y;return Math.hypot(s,c)}}}],[0]);"`;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
This allows the minify function to be passed contextual information providing a method for minified settings to be calculated based on external factors when the `parallel` option is enabled.

Hypothetical Example:

```
const minifyContext = {
  noMangle: true
};

const plugin = new UglifyJsPlugin({
  parallel: true,
  minifyContext,
  minify(file, sourceMap, context) {
    // eslint-disable-next-line global-require
    return require('terser').minify(file, {
      mangle: !context.noMangle,
    });
  },
});
```