### PR TITLE
fix: ping uglify-js to an older version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "schema-utils": "^1.0.0",
     "serialize-javascript": "^1.4.0",
     "source-map": "^0.6.1",
-    "uglify-js": "^3.4.9",
+    "uglify-js": "^3.1.4",
     "webpack-sources": "^1.1.0",
     "worker-farm": "^1.5.2"
   },


### PR DESCRIPTION
This allows users of the plugin to pin to older versions to avoid bugs.
3.1.4 picked purely because its in the package lock file as what handlebars pins to.
Fixes #355

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

See bug #355 
