### PR TITLE
fix(index): handle `chunks` provided as a `{Set}`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ class UglifyJsPlugin {
       const processedAssets = new WeakSet();
       const tasks = [];
 
-      chunks
+      Array.from(chunks)
         .reduce((acc, chunk) => acc.concat(chunk.files || []), [])
         .concat(compilation.additionalChunkAssets || [])
         .filter(ModuleFilenameHelpers.matchObject.bind(null, this.options))


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In webpack@5, `chunks` is a `Set` and thus should be converted to an array.

### Breaking Changes

n/a

### Additional Info

This change makes the plugin compatible with webpack 4 and 5.