### PR TITLE
feat: don't compute input source maps if source file hasn't changed

### DIFF
--- a/src/TaskRunner.js
+++ b/src/TaskRunner.js
@@ -78,11 +78,7 @@ export default class TaskRunner {
 
           if (this.cacheDir && !result.error) {
             cacache
-              .put(
-                this.cacheDir,
-                serialize(task.cacheKeys),
-                JSON.stringify(data)
-              )
+              .put(this.cacheDir, task.cacheKey, JSON.stringify(data))
               .then(done, done);
           } else {
             done();
@@ -92,7 +88,7 @@ export default class TaskRunner {
 
       if (this.cacheDir) {
         cacache
-          .get(this.cacheDir, serialize(task.cacheKeys))
+          .get(this.cacheDir, task.cacheKey)
           .then(({ data }) => step(index, JSON.parse(data)), enqueue);
       } else {
         enqueue();


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The plugin does a lot of work computing input source maps when it isn't necessary, i.e. the cache key hasn't changed and we already have a source map in our cache for the key.

### Breaking Changes

This shouldn't be a breaking change, but I'm not super familiar with all of the possible configurations for this plugin.

### Additional Info

This change looks a lot bigger than it actually is.  Because of the `cacache.get.info()` call that's introduced index, I had to wrap a big chunk of `optimizeFn` in a `Promise.all()` call because `cacache.get.info()` returns a promise and before this everything in `optimizeFn` was synchronous.